### PR TITLE
Updated url formatting for notes

### DIFF
--- a/src/pages/job/[id].tsx
+++ b/src/pages/job/[id].tsx
@@ -317,7 +317,7 @@ const Notes = ({ notes }: { notes: string }) => {
               target="_blank"
               className="text-red-600 italic"
             >
-              {text}
+              {text.split('/')[2]}
             </a>
           );
         }


### PR DESCRIPTION
Urls will be auto formatted as main link instead of complete link. Example `https://walmart.wd5.myworkdayjobs.com/en-US/WalmartExternal/userHome` will be formatted as `walmart.wd5.myworkdayjobs`